### PR TITLE
Fixing issues preventing the ssl recipe from working. Move quick; break things. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .kitchen/*
-.s3.yml
+.ssl.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,15 @@
 ---
+<%
+# If you want to test the SSL certs, please create a .ssl.yml file with
+# some valid settings for an s3 bucket, cert and key. 
+# TODO: let's fix this to be mockable. 
+if File.exist?('.ssl.yml')
+  ssl = YAML.load_file('.ssl.yml')
+else
+  ssl = {}
+end
+%>
+
 driver:
   name: vagrant
 
@@ -6,8 +17,6 @@ provisioner:
   name: chef_zero
   always_update_cookbooks: true
   require_chef_omnibus: 12
-
-<% s3 = YAML.load_file('.s3.yml') %>
 
 verifier:
   name: inspec
@@ -29,10 +38,10 @@ suites:
     run_list:
       - recipe[looker::ssl]
     attributes:
-      - looker:
+      looker:
         ssl: 
-          aws_access_key_id: <%= s3['aws_access_key_id'] %>
-          aws_secret_access_key: <%= s3['aws_secret_access_key'] %>
-          s3_bucket: <%= s3['s3_bucket'] %>
-          certificate_key_path: <%= s3['certificate_key_path'] %>
-          certificate_path: <%= s3['certificate_path']%>
+          aws_access_key_id: <%= ssl['aws_access_key_id'] %>
+          aws_secret_access_key: <%= ssl['aws_secret_access_key'] %>
+          s3_bucket: <%= ssl['s3_bucket'] %>
+          certificate_key_path: <%= ssl['certificate_key_path'] %>
+          certificate_path: <%= ssl['certificate_path']%>

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,5 +1,5 @@
 DEPENDENCIES
-  aws
+  aws (~> 7)
   java (~> 1.50.0)
   looker
     path: .
@@ -13,7 +13,7 @@ GRAPH
     apt (>= 0.0.0)
     homebrew (>= 0.0.0)
     windows (>= 0.0.0)
-  looker (0.2.1)
+  looker (0.3.1)
     aws (>= 0.0.0)
     java (>= 0.0.0)
   ohai (5.2.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,8 @@
+#
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# Attributes:: default
+#
 
 # looker general attributes
 default['looker']['looker_user']        = 'looker'

--- a/attributes/setup.rb
+++ b/attributes/setup.rb
@@ -1,3 +1,12 @@
+#
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# Attributes:: setup
+#
+
+# TODO: hold this in place until we get the checkout from gethub of the
+# looker models...
+#
 
 # home_dir = ::File.join('/', 'home', node[:deliv_looker][:user])
 # base_dir = node[:deliv_looker][:base_dir]
@@ -12,6 +21,3 @@
 #   default[:deliv_looker][:setup][:symlinks][path] =
 #     ::File.join(home_dir, '.ssh', ::File.basename(path))
 # end
-
-default['looker']['setup']['download_url'] = 'https://s3.amazonaws.com/' \
-  'download.looker.com/aeHee2HiNeekoh3uIu6hec3W/looker-latest.jar'

--- a/attributes/ssl.rb
+++ b/attributes/ssl.rb
@@ -1,3 +1,8 @@
+#
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# Attributes:: ssl
+#
 
 # if you'd like to have looker use a custom SSL certificate you'll
 # want to populate these values
@@ -13,12 +18,9 @@ default['looker']['ssl']['keystore_password']       = Array.new(10)
                                                            .join
 
 if node['looker']['use_custom_ssl']
-  ssl_dir = File.join(node['looker']['looker_dir'], ssl)
+  ssl_dir = File.join(node['looker']['looker_dir'], '.ssl')
   args = " --ssl-keystore=#{File.join(ssl_dir, 'looker.jks')} "\
          " --ssl-keystore-pass-file=#{File.join(ssl_dir, '.keystorepass')} "
-
-  #  default['looker'][:jar_start_args] = ' --ssl-keystore=/home/looker/looker/.ssl/looker.jks '\
-  #                                      ' --ssl-keystore-pass-file=/home/looker/looker/.ssl/.keystorepass'
 
   default['looker']['jar_start_args'] = args
 end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -17,9 +17,7 @@ directory node['looker']['looker_dir'] do
   action :create
 end
 
-if node['looker']['use_custom_ssl']
-  include_recipe 'looker::ssl'
-end
+include_recipe 'looker::ssl' if node['looker']['use_custom_ssl']
 
 # Download looker
 # We'll keep a local copy of it in the home directory, for convienience

--- a/test/integration/setup/setup_test.rb
+++ b/test/integration/setup/setup_test.rb
@@ -1,6 +1,8 @@
 # # encoding: utf-8
 #
-# Inspec test for recipe looker::setup
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# test:: default
 #
 
 describe user('looker') do

--- a/test/integration/ssl/ssl_test.rb
+++ b/test/integration/ssl/ssl_test.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+#
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# test:: ssl
+#

--- a/test/integration/user/user_test.rb
+++ b/test/integration/user/user_test.rb
@@ -1,6 +1,9 @@
-# # encoding: utf-8
-
-# Inspec test for recipe deliv_looker::default
+# encoding: utf-8
+#
+# Author:: Barclay Loftus (<barclay@deliv.co>)
+# Cookbook:: looker
+# test:: user
+#
 
 describe group('looker') do
   it { should exist }


### PR DESCRIPTION
As trying to move our production deploy to use this recipe, I ran into some issues in the `ssl` recipe (more than one). 

Doing a bunch of cleanup there. Also renaming the poorly named `s3.yml` to `ssl.yml`. 

We still need to think of some specs for the `ssl` recipe. Working on that. 